### PR TITLE
Allow a Factory for custom creation of the Guard User object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## [Unreleased]
-
+### Added
+- Possibility to specify an "AuthWrapperFactory" allowing custom creation of the User object
 
 ## [1.5.0] - 2018-11-03
 ### Added

--- a/resources/config.php
+++ b/resources/config.php
@@ -18,7 +18,8 @@ return [
 
     'resource_owner_attribute' => 'oauth2_user',
     'auth_driver_key' => 'oauth2',
-    'authWrapper' => \Kronthto\LaravelOAuth2Login\OAuthUserWrapper::class,
+    'authWrapperFactory' => null, // Can be used to specify a factory with an __invoke (ResourceOwnerInterface passed as arg1) method to build a custom User object
+    'authWrapper' => \Kronthto\LaravelOAuth2Login\OAuthUserWrapper::class, // Ignored if authWrapperFactory is not null
 
     'cacheUserDetailsFor' => 30, // minutes
     'cacheUserPrefix' => 'oauth_user_',

--- a/src/AuthFromRequest.php
+++ b/src/AuthFromRequest.php
@@ -21,6 +21,11 @@ class AuthFromRequest
             return null;
         }
 
+        $wrapperFactory = config('oauth2login.authWrapperFactory');
+        if (null !== $wrapperFactory) {
+            return app($wrapperFactory)($resourceOwner);
+        }
+
         $wrapperClass = config('oauth2login.authWrapper');
 
         return new $wrapperClass($resourceOwner);

--- a/src/AuthFromRequest.php
+++ b/src/AuthFromRequest.php
@@ -23,7 +23,9 @@ class AuthFromRequest
 
         $wrapperFactory = config('oauth2login.authWrapperFactory');
         if (null !== $wrapperFactory) {
-            return app($wrapperFactory)($resourceOwner);
+            $factoryInstance = app($wrapperFactory);
+
+            return $factoryInstance($resourceOwner);
         }
 
         $wrapperClass = config('oauth2login.authWrapper');

--- a/tests/CustomAuthFactoryTest.php
+++ b/tests/CustomAuthFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests;
+
+use Kronthto\LaravelOAuth2Login\OAuthProviderService;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessToken;
+
+class CustomAuthFactoryTest extends MiddlewareTest
+{
+    public function testUsesFactoryFromConfigToConstructUser()
+    {
+        config()->set('oauth2login.authWrapperFactory', DemoFactory::class);
+
+        $token = new AccessToken([
+            'access_token' => 'blabla',
+            'expires' => time() + 100000,
+        ]);
+
+        /** @var OAuthProviderService|\PHPUnit_Framework_MockObject_MockObject $oauthProviderMock */
+        $oauthProviderMock = $this->getMockBuilder(OAuthProviderService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $userInfo = new GenericResourceOwner([
+            'email' => 'foo2@bar.de',
+        ], 'email');
+        $oauthProviderMock->method('getTokenUser')->with($token)->willReturn($userInfo);
+        $this->app->instance(OAuthProviderService::class, $oauthProviderMock);
+
+        // Call to init Guard
+        $this->withSession([
+            config('oauth2login.session_key') => $token,
+        ])->get('web/email');
+
+        $authGuard = \Auth::guard('oauth2guard');
+        $this->assertInstanceOf(DemoUserClass::class, $authGuard->user());
+        $this->assertEquals('foo2@bar.de', $authGuard->user()->demokey);
+    }
+}
+
+class DemoUserClass
+{
+    public $demokey;
+}
+
+class DemoFactory
+{
+    public function __invoke(ResourceOwnerInterface $resourceOwner)
+    {
+        $inst = new DemoUserClass();
+        $inst->demokey = $resourceOwner->toArray()['email'];
+
+        return $inst;
+    }
+}


### PR DESCRIPTION
See #5

Defaults to `null` and the old logic.